### PR TITLE
Add example

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,17 @@ python pipeline_runner.py \
   --genes GENE1 GENE2 ... \
   [--out output_dir]
 ```
+**Example:**
+
+```bash
+python pipeline_runner.py \
+  --h5ads gw18_umb1759.h5ad gw20_umb1031.h5ad gw21_umb1932.h5ad \
+  --triples FB123 F1 A-PFC \
+  --triples FB123 O2 A-Occi \
+  --sr FB123-F1 FB123-O2 \
+  --genes CBLN2 SRM RASGRF2 MYOG XYZ123 \
+  --out spatial_analysis_results
+```
 
 This single command will:
 


### PR DESCRIPTION
This pull request adds an example usage section to the `README.md` file to demonstrate how to run the `pipeline_runner.py` script with specific arguments.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R151-R161): Added an example usage block for the `pipeline_runner.py` script, showcasing the required and optional arguments such as `--h5ads`, `--triples`, `--sr`, `--genes`, and `--out`. This improves clarity for users on how to execute the script.